### PR TITLE
Remove rvm from the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 dist: bionic
-rvm:
-  - 2.6
 script:
   - bin/rubocop
   - bin/rspec


### PR DESCRIPTION
According to the Travis docs, when this directive isn't present in the
config file Travis will use .ruby-version which we have set to our
version of ruby. This didn't work at first for some reason, but it seems
to work now.